### PR TITLE
Make Request extension public

### DIFF
--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -8,7 +8,7 @@ public protocol Request {
   func parse(j: JSON) -> Result<ResponseType, NSError>
 }
 
-extension Request where ResponseType: Decodable, ResponseType.DecodedType == ResponseType {
+public extension Request where ResponseType: Decodable, ResponseType.DecodedType == ResponseType {
   func parse(j: JSON) -> Result<ResponseType, NSError> {
     return .fromDecoded(ResponseType.decode(j))
   }


### PR DESCRIPTION
If this isn't public, the code consuming this lib doesn't know about the
default implementation, and so this does nothing. We need to make this
public in order to let people use it.
