### PR TITLE
Perform completion handler on main thread

### DIFF
--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -14,7 +14,7 @@ public extension APIClient {
   func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> Void) {
     requestPerformer.performRequest(request.build()) { result in
       let object = result >>- deserialize >>- { request.parse($0) }
-      completionHandler(object)
+      dispatch_async(dispatch_get_main_queue()) { completionHandler(object) }
     }
   }
 }


### PR DESCRIPTION
This add a simple `dispatch_async` to the `APIClient` so that it calls the
completion handler on the main thread. Tests have been updated to handle async.
