### PR TITLE
Add default parse method for Decodable collections

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "thoughtbot/Argo" "235b4bdc2e11121cc15cedc9465401e6bc002a06"
+github "thoughtbot/Argo" "f26d51f4e1caf3860996a44bc85d9da4f4d8a303"
 github "Quick/Nimble" "v2.0.0-rc.3"
 github "Quick/Quick" "v0.6.0"
 github "antitypical/Result" "0.6.0-beta.3"

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -13,3 +13,9 @@ public extension Request where ResponseType: Decodable, ResponseType.DecodedType
     return .fromDecoded(ResponseType.decode(j))
   }
 }
+
+public extension Request where ResponseType: CollectionType, ResponseType.Generator.Element: Decodable, ResponseType.Generator.Element.DecodedType == ResponseType.Generator.Element {
+  func parse(j: JSON) -> Result<[ResponseType.Generator.Element], NSError> {
+    return .fromDecoded(ResponseType.decode(j))
+  }
+}

--- a/Swish.xcodeproj/project.pbxproj
+++ b/Swish.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		F88ED0791B96847E0069F56C /* FakeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88ED0781B96847E0069F56C /* FakeRequest.swift */; settings = {ASSET_TAGS = (); }; };
 		F88ED07B1B9684B40069F56C /* FakeRequestPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88ED07A1B9684B40069F56C /* FakeRequestPerformer.swift */; settings = {ASSET_TAGS = (); }; };
 		F88EE3141B976747001EEB44 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88ED0711B967C4A0069F56C /* Result.swift */; settings = {ASSET_TAGS = (); }; };
+		F8A00DE71BB5C86200169A46 /* RequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A00DE61BB5C86200169A46 /* RequestSpec.swift */; settings = {ASSET_TAGS = (); }; };
 		F8C39B511B969A71005E065F /* FakeDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C39B501B969A71005E065F /* FakeDataTask.swift */; settings = {ASSET_TAGS = (); }; };
 		F8DF3B861B964B20003177CD /* FakeSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DF3B811B964B20003177CD /* FakeSession.swift */; settings = {ASSET_TAGS = (); }; };
 		F8DF3B881B964B20003177CD /* NetworkRequestPerformerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DF3B851B964B20003177CD /* NetworkRequestPerformerSpec.swift */; settings = {ASSET_TAGS = (); }; };
@@ -52,6 +53,7 @@
 		F88ED0711B967C4A0069F56C /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		F88ED0781B96847E0069F56C /* FakeRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeRequest.swift; sourceTree = "<group>"; };
 		F88ED07A1B9684B40069F56C /* FakeRequestPerformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeRequestPerformer.swift; sourceTree = "<group>"; };
+		F8A00DE61BB5C86200169A46 /* RequestSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestSpec.swift; sourceTree = "<group>"; };
 		F8C39B501B969A71005E065F /* FakeDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeDataTask.swift; sourceTree = "<group>"; };
 		F8DF3B811B964B20003177CD /* FakeSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeSession.swift; sourceTree = "<group>"; };
 		F8DF3B831B964B20003177CD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 			isa = PBXGroup;
 			children = (
 				F8DF3B851B964B20003177CD /* NetworkRequestPerformerSpec.swift */,
+				F8A00DE61BB5C86200169A46 /* RequestSpec.swift */,
 				F88ED06E1B967BCB0069F56C /* APIClientSpec.swift */,
 			);
 			path = Tests;
@@ -322,6 +325,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8DF3B881B964B20003177CD /* NetworkRequestPerformerSpec.swift in Sources */,
+				F8A00DE71BB5C86200169A46 /* RequestSpec.swift in Sources */,
 				F8C39B511B969A71005E065F /* FakeDataTask.swift in Sources */,
 				F8DF3B861B964B20003177CD /* FakeSession.swift in Sources */,
 				F88ED0791B96847E0069F56C /* FakeRequest.swift in Sources */,

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -1,0 +1,57 @@
+@testable import Swish
+import Argo
+import Quick
+import Nimble
+import Result
+
+struct User: Decodable {
+  let name: String
+  
+  static func decode(json: JSON) -> Decoded<User> {
+    return User.init <^> json <| "name"
+  }
+}
+
+struct DecodableRequest: Request {
+  typealias ResponseType = User
+  
+  func build() -> NSURLRequest {
+    return NSURLRequest()
+  }
+}
+
+struct DecodableCollectionRequest: Request {
+  typealias ResponseType = [User]
+  
+  func build() -> NSURLRequest {
+    return NSURLRequest()
+  }
+}
+
+class RequestSpec: QuickSpec {
+  override func spec() {
+    describe("Request") {
+      describe("default parse implementation") {
+        context("when the ResponseType is decodable") {
+          let request = DecodableRequest()
+          let json = JSON.parse(["name": "gvg"])
+          let result = request.parse(json)
+          
+          expect(result.value?.name).to(equal("gvg"))
+        }
+        
+        context("when the ResponseType is a collection type of decodable objects") {
+          let request = DecodableCollectionRequest()
+          let json = JSON.parse([
+            ["name": "giles"],
+            ["name": "gordon"]
+          ])
+          let result = request.parse(json)
+          
+          expect(result.value?.count).to(equal(2))
+          expect(result.value?.first?.name).to(equal("giles"))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We added a default implementation for parse if the response type was
`Decodable`, but weren't able to do the same for collections of decodable
types, because of how Argo implemented the Array extension. With
thoughtbot/Argo#243, we can actually extend Request to automatically parse
ResponseTypes that are CollectionTypes whose elements are themselves
Decodable.

We should point Argo back at master once that PR gets merged.
