### PR TITLE
Make NetworkRequestPerformer public.

### DIFF
--- a/Source/Models/NetworkRequestPerformer.swift
+++ b/Source/Models/NetworkRequestPerformer.swift
@@ -4,7 +4,7 @@ import Result
 public struct NetworkRequestPerformer: RequestPerformer {
   private let session: NSURLSession
 
-  init(session: NSURLSession = NSURLSession.sharedSession()) {
+  public init(session: NSURLSession = NSURLSession.sharedSession()) {
     self.session = session
   }
 }

--- a/Source/Models/NetworkRequestPerformer.swift
+++ b/Source/Models/NetworkRequestPerformer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Result
 
-struct NetworkRequestPerformer: RequestPerformer {
+public struct NetworkRequestPerformer: RequestPerformer {
   private let session: NSURLSession
 
   init(session: NSURLSession = NSURLSession.sharedSession()) {
@@ -9,7 +9,7 @@ struct NetworkRequestPerformer: RequestPerformer {
   }
 }
 
-extension NetworkRequestPerformer {
+public extension NetworkRequestPerformer {
   func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) {
     session.dataTaskWithRequest(request) { data, response, error in
       if let error = error {


### PR DESCRIPTION
This pull request makes `NetworkRequestPerformer` public, as discussed in #19.

I think I'm right in also making the extension public.

fixes #19 
