### PR TITLE
Update Argo.

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "thoughtbot/Argo" "f26d51f4e1caf3860996a44bc85d9da4f4d8a303"
+github "thoughtbot/Argo" "b0b6920e5c34591e3884a4e50a740167e6cbaf68"
 github "Quick/Nimble" "v2.0.0-rc.3"
 github "Quick/Quick" "v0.6.0"
 github "antitypical/Result" "0.6.0-beta.3"


### PR DESCRIPTION
This pull request points Argo to the same change but using a different commit SHA.

This is to address the issue described here: https://github.com/Carthage/Carthage/issues/812#issuecomment-145303514

I think the root cause is the force push that happened here: https://github.com/thoughtbot/Argo/pull/237#issuecomment-144621084
