### PR TITLE
Add Xcode SCM blueprint files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.pbxuser
 xcuserdata
 *.xccheckout
+*.xcscmblueprint
 
 # Build products
 build/


### PR DESCRIPTION
These were showing up as untracked files in my working directory.

Normally I'd use https://github.com/github/gitignore/blob/master/Swift.gitignore but there were some differences here. Happy to make further changes to that effect.
