### PR TITLE
Add default protocol implementation for parse() where ResponseType is Void

### DIFF
--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -19,3 +19,9 @@ public extension Request where ResponseType: CollectionType, ResponseType.Genera
     return .fromDecoded(ResponseType.decode(j))
   }
 }
+
+public extension Request where ResponseType == Void {
+  func parse(j: JSON) -> Result<ResponseType, NSError> {
+    return .Success()
+  }
+}

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -2,6 +2,8 @@ import Foundation
 import Argo
 import Result
 
+public typealias EmptyResponse = Void
+
 public protocol Request {
   typealias ResponseType
   func build() -> NSURLRequest
@@ -20,7 +22,7 @@ public extension Request where ResponseType: CollectionType, ResponseType.Genera
   }
 }
 
-public extension Request where ResponseType == Void {
+public extension Request where ResponseType == EmptyResponse {
   func parse(j: JSON) -> Result<ResponseType, NSError> {
     return .Success()
   }

--- a/Tests/Helpers/NimbleMatchers.swift
+++ b/Tests/Helpers/NimbleMatchers.swift
@@ -1,4 +1,5 @@
 import Nimble
+import Result
 
 public func beVoid() -> MatcherFunc<Void> {
   return MatcherFunc { actualExpression, failureMessage in
@@ -10,6 +11,17 @@ public func beVoid() -> MatcherFunc<Void> {
       return true
     default:
       return false
+    }
+  }
+}
+
+public func beSuccessful<T, E>() -> NonNilMatcherFunc<Result<T, E>> {
+  return NonNilMatcherFunc { actual, failure in
+    let result = try actual.evaluate()
+    
+    switch result {
+    case .Success?: return true
+    default: return false
     }
   }
 }

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -63,8 +63,7 @@ class RequestSpec: QuickSpec {
         context("when the ResponseType is an EmptyResponse") {
           it("should have a nil Result value") {
             let request = EmptyResponseRequest()
-            let json = JSON.parse([])
-            let result = request.parse(json)
+            let result = request.parse(.Null)
             
             switch result {
             case .Success:

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -28,6 +28,14 @@ struct DecodableCollectionRequest: Request {
   }
 }
 
+struct VoidResponseRequest: Request {
+  typealias ResponseType = Void
+  
+  func build() -> NSURLRequest {
+    return NSURLRequest()
+  }
+}
+
 class RequestSpec: QuickSpec {
   override func spec() {
     describe("Request") {
@@ -50,6 +58,21 @@ class RequestSpec: QuickSpec {
           
           expect(result.value?.count).to(equal(2))
           expect(result.value?.first?.name).to(equal("giles"))
+        }
+        
+        context("when the ResponseType is Void") {
+          it("should have a nil Result value") {
+            let request = VoidResponseRequest()
+            let json = JSON.parse([])
+            let result = request.parse(json)
+            
+            switch result {
+            case .Success:
+              XCTAssert(true)
+            default:
+              XCTFail("Unexpected Failure")
+            }            
+          }
         }
       }
     }

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -28,8 +28,8 @@ struct DecodableCollectionRequest: Request {
   }
 }
 
-struct VoidResponseRequest: Request {
-  typealias ResponseType = Void
+struct EmptyResponseRequest: Request {
+  typealias ResponseType = EmptyResponse
   
   func build() -> NSURLRequest {
     return NSURLRequest()
@@ -60,9 +60,9 @@ class RequestSpec: QuickSpec {
           expect(result.value?.first?.name).to(equal("giles"))
         }
         
-        context("when the ResponseType is Void") {
+        context("when the ResponseType is an EmptyResponse") {
           it("should have a nil Result value") {
-            let request = VoidResponseRequest()
+            let request = EmptyResponseRequest()
             let json = JSON.parse([])
             let result = request.parse(json)
             

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -61,16 +61,11 @@ class RequestSpec: QuickSpec {
         }
         
         context("when the ResponseType is an EmptyResponse") {
-          it("should have a nil Result value") {
+          it("should result in Success") {
             let request = EmptyResponseRequest()
             let result = request.parse(.Null)
             
-            switch result {
-            case .Success:
-              XCTAssert(true)
-            default:
-              XCTFail("Unexpected Failure")
-            }            
+            expect(result).to(beSuccessful())
           }
         }
       }


### PR DESCRIPTION
I found that I needed this today when requests to a particular API endpoint returned a `204` response.

I tried implementing a more meaningful test but couldn't figure out a way that allowed comparison of `()`, `Result<Void, NSError>.Success()`, or its `value`.
