### PR TITLE
Add JSON payload extensions to NSURLRequest

### DIFF
--- a/Source/Extensions/NSURLRequest.swift
+++ b/Source/Extensions/NSURLRequest.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public extension NSURLRequest {
+  var jsonPayload: NSDictionary {
+    let json = HTTPBody.flatMap { try? NSJSONSerialization.JSONObjectWithData($0, options: NSJSONReadingOptions(rawValue: 0)) }
+    return (json as? [String: AnyObject]) ?? [:]
+  }
+}
+
+public extension NSMutableURLRequest {
+  override var jsonPayload: NSDictionary {
+    get {
+      return super.jsonPayload
+    }
+
+    set {
+      HTTPBody = try? NSJSONSerialization.dataWithJSONObject(newValue, options: NSJSONWritingOptions(rawValue: 0))
+    }
+  }
+}

--- a/Swish.xcodeproj/project.pbxproj
+++ b/Swish.xcodeproj/project.pbxproj
@@ -30,6 +30,10 @@
 		2C721E5D1BD5A7E800846414 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88ED06C1B96736B0069F56C /* APIClient.swift */; };
 		2C721E5E1BD5A83B00846414 /* Swish.h in Headers */ = {isa = PBXBuildFile; fileRef = F80695121B962C5300C61B4A /* Swish.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E506EC7E1BB5BE380032E941 /* NimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E506EC7D1BB5BE380032E941 /* NimbleMatchers.swift */; settings = {ASSET_TAGS = (); }; };
+		E5915B211BDABC4B005E5D63 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5915B201BDABC4B005E5D63 /* NSURLRequest.swift */; settings = {ASSET_TAGS = (); }; };
+		E5915B221BDABC4B005E5D63 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5915B201BDABC4B005E5D63 /* NSURLRequest.swift */; settings = {ASSET_TAGS = (); }; };
+		E5915B241BDAD1A3005E5D63 /* NSURLRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5915B231BDAD1A3005E5D63 /* NSURLRequestSpec.swift */; settings = {ASSET_TAGS = (); }; };
+		E5915B251BDAD1A3005E5D63 /* NSURLRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5915B231BDAD1A3005E5D63 /* NSURLRequestSpec.swift */; settings = {ASSET_TAGS = (); }; };
 		E5D7E0A11BBF2021002A3738 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D7E0A01BBF2021002A3738 /* Client.swift */; settings = {ASSET_TAGS = (); }; };
 		F80694FC1B962BB900C61B4A /* Swish.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F80694F11B962BB900C61B4A /* Swish.framework */; settings = {ASSET_TAGS = (); }; };
 		F80695131B962C5300C61B4A /* NetworkRequestPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F806950D1B962C5300C61B4A /* NetworkRequestPerformer.swift */; settings = {ASSET_TAGS = (); }; };
@@ -74,6 +78,8 @@
 		2C721E401BD5A77700846414 /* Swish.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swish.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C721E491BD5A77700846414 /* Swish-MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Swish-MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E506EC7D1BB5BE380032E941 /* NimbleMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleMatchers.swift; sourceTree = "<group>"; };
+		E5915B201BDABC4B005E5D63 /* NSURLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLRequest.swift; sourceTree = "<group>"; };
+		E5915B231BDAD1A3005E5D63 /* NSURLRequestSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLRequestSpec.swift; sourceTree = "<group>"; };
 		E5D7E0A01BBF2021002A3738 /* Client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		F80694F11B962BB900C61B4A /* Swish.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swish.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F80694FB1B962BB900C61B4A /* Swish-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Swish-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -217,6 +223,7 @@
 		F88ED0701B967C320069F56C /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				E5915B201BDABC4B005E5D63 /* NSURLRequest.swift */,
 				F88ED0711B967C4A0069F56C /* Result.swift */,
 			);
 			path = Extensions;
@@ -269,6 +276,7 @@
 				F8DF3B851B964B20003177CD /* NetworkRequestPerformerSpec.swift */,
 				F8A00DE61BB5C86200169A46 /* RequestSpec.swift */,
 				F88ED06E1B967BCB0069F56C /* APIClientSpec.swift */,
+				E5915B231BDAD1A3005E5D63 /* NSURLRequestSpec.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -449,6 +457,7 @@
 				2C61A39E1BD726E10087B295 /* RequestMethod.swift in Sources */,
 				2C721E5D1BD5A7E800846414 /* APIClient.swift in Sources */,
 				2C721E591BD5A7C500846414 /* Client.swift in Sources */,
+				E5915B221BDABC4B005E5D63 /* NSURLRequest.swift in Sources */,
 				2C721E581BD5A7C500846414 /* HTTPResponse.swift in Sources */,
 				2C721E5C1BD5A7E800846414 /* NetworkRequestPerformer.swift in Sources */,
 				2C721E571BD5A7C500846414 /* Result.swift in Sources */,
@@ -464,6 +473,7 @@
 				2C6DC9811BD5AA3B006B4C96 /* APIClientSpec.swift in Sources */,
 				2C6DC97E1BD5AA3B006B4C96 /* FakeDataTask.swift in Sources */,
 				2C6DC97C1BD5AA3B006B4C96 /* FakeRequest.swift in Sources */,
+				E5915B251BDAD1A3005E5D63 /* NSURLRequestSpec.swift in Sources */,
 				2C6DC97D1BD5AA3B006B4C96 /* FakeRequestPerformer.swift in Sources */,
 				2C6DC97B1BD5AA3B006B4C96 /* FakeSession.swift in Sources */,
 				2C6DC97F1BD5AA3B006B4C96 /* NetworkRequestPerformerSpec.swift in Sources */,
@@ -483,6 +493,7 @@
 				F88ED0691B966E650069F56C /* Request.swift in Sources */,
 				F80695141B962C5300C61B4A /* RequestPerformer.swift in Sources */,
 				F88ED06D1B96736B0069F56C /* APIClient.swift in Sources */,
+				E5915B211BDABC4B005E5D63 /* NSURLRequest.swift in Sources */,
 				F80695131B962C5300C61B4A /* NetworkRequestPerformer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -494,6 +505,7 @@
 				F8DF3B881B964B20003177CD /* NetworkRequestPerformerSpec.swift in Sources */,
 				F8A00DE71BB5C86200169A46 /* RequestSpec.swift in Sources */,
 				F8C39B511B969A71005E065F /* FakeDataTask.swift in Sources */,
+				E5915B241BDAD1A3005E5D63 /* NSURLRequestSpec.swift in Sources */,
 				F8DF3B861B964B20003177CD /* FakeSession.swift in Sources */,
 				F88ED0791B96847E0069F56C /* FakeRequest.swift in Sources */,
 				E506EC7E1BB5BE380032E941 /* NimbleMatchers.swift in Sources */,

--- a/Tests/Tests/NSURLRequestSpec.swift
+++ b/Tests/Tests/NSURLRequestSpec.swift
@@ -1,0 +1,32 @@
+import Swish
+import Quick
+import Nimble
+
+class NSURLRequestSpec: QuickSpec {
+  override func spec() {
+    describe("jsonPayload") {
+      context("when given an encodable object") {
+        it("serializes and deserializes correctly") {
+          let urlRequest = NSMutableURLRequest(URL: NSURL(string: "http://www.example.com")!)
+          urlRequest.jsonPayload = ["ids": [0, 1, 2]]
+
+          let payloadFromRequest = urlRequest.jsonPayload
+          let ids: [Int]? = payloadFromRequest["ids"] as? [Int]
+
+          expect(ids).to(equal([0, 1, 2]))
+        }
+      }
+
+      context("when the HTTPBody cannot be decoded") {
+        it("returns an empty dictionary") {
+          let urlRequest = NSMutableURLRequest(URL: NSURL(string: "http://www.example.com")!)
+          urlRequest.HTTPBody = NSData()
+
+          let payloadFromRequest = urlRequest.jsonPayload
+
+          expect(payloadFromRequest.count).to(equal(0))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
WRT https://github.com/thoughtbot/Swish/issues/27

We've used these on a couple projects now, and they've proven useful! Most commonly used in the `build()` function of the `Request` protocol, for `POST` requests and the like.
