### PR TITLE
Clean up the API client a little

### DIFF
--- a/Source/Extensions/GCD.swift
+++ b/Source/Extensions/GCD.swift
@@ -1,0 +1,3 @@
+func onMain(f: dispatch_block_t)  {
+  dispatch_async(dispatch_get_main_queue(), f)
+}

--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -13,7 +13,7 @@ public struct APIClient {
 extension APIClient: Client {
   public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> Void) {
     requestPerformer.performRequest(request.build()) { result in
-      let object = result >>- deserialize >>- { request.parse($0) }
+      let object = result >>- deserialize >>- request.parse
       dispatch_async(dispatch_get_main_queue()) { completionHandler(object) }
     }
   }

--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -14,7 +14,7 @@ extension APIClient: Client {
   public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> Void) {
     requestPerformer.performRequest(request.build()) { result in
       let object = result >>- deserialize >>- request.parse
-      dispatch_async(dispatch_get_main_queue()) { completionHandler(object) }
+      onMain { completionHandler(object) }
     }
   }
 }

--- a/Swish.xcodeproj/project.pbxproj
+++ b/Swish.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		F8DF3B881B964B20003177CD /* NetworkRequestPerformerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DF3B851B964B20003177CD /* NetworkRequestPerformerSpec.swift */; settings = {ASSET_TAGS = (); }; };
 		F8A7CADC1BFD5EBD008B9224 /* NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D09FB81BFD360A00FB2433 /* NSError.swift */; };
 		F8D09FB91BFD360A00FB2433 /* NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D09FB81BFD360A00FB2433 /* NSError.swift */; };
+		F8D09FBC1BFD48F200FB2433 /* GCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D09FBB1BFD48F200FB2433 /* GCD.swift */; };
+		F8D09FBD1BFD48F200FB2433 /* GCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D09FBB1BFD48F200FB2433 /* GCD.swift */; };
 		F8DF3B8B1B964B83003177CD /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DF3B891B964B83003177CD /* Nimble.framework */; };
 		F8DF3B8C1B964B83003177CD /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DF3B8A1B964B83003177CD /* Quick.framework */; };
 		F8DF3B8E1B964BED003177CD /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DF3B8D1B964BED003177CD /* HTTPResponse.swift */; settings = {ASSET_TAGS = (); }; };
@@ -101,6 +103,7 @@
 		F8A00DE61BB5C86200169A46 /* RequestSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestSpec.swift; sourceTree = "<group>"; };
 		F8C39B501B969A71005E065F /* FakeDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeDataTask.swift; sourceTree = "<group>"; };
 		F8D09FB81BFD360A00FB2433 /* NSError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSError.swift; sourceTree = "<group>"; };
+		F8D09FBB1BFD48F200FB2433 /* GCD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GCD.swift; sourceTree = "<group>"; };
 		F8DF3B811B964B20003177CD /* FakeSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeSession.swift; sourceTree = "<group>"; };
 		F8DF3B831B964B20003177CD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8DF3B851B964B20003177CD /* NetworkRequestPerformerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkRequestPerformerSpec.swift; sourceTree = "<group>"; };
@@ -229,6 +232,7 @@
 				F8D09FB81BFD360A00FB2433 /* NSError.swift */,
 				E5915B201BDABC4B005E5D63 /* NSURLRequest.swift */,
 				F88ED0711B967C4A0069F56C /* Result.swift */,
+				F8D09FBB1BFD48F200FB2433 /* GCD.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -465,6 +469,7 @@
 				2C721E581BD5A7C500846414 /* HTTPResponse.swift in Sources */,
 				2C721E5C1BD5A7E800846414 /* NetworkRequestPerformer.swift in Sources */,
 				2C721E571BD5A7C500846414 /* Result.swift in Sources */,
+				F8D09FBD1BFD48F200FB2433 /* GCD.swift in Sources */,
 				2C721E5B1BD5A7D400846414 /* Request.swift in Sources */,
 				2C721E5A1BD5A7D400846414 /* RequestPerformer.swift in Sources */,
 				F8A7CADC1BFD5EBD008B9224 /* NSError.swift in Sources */,
@@ -498,6 +503,7 @@
 				F88ED0691B966E650069F56C /* Request.swift in Sources */,
 				F80695141B962C5300C61B4A /* RequestPerformer.swift in Sources */,
 				F88ED06D1B96736B0069F56C /* APIClient.swift in Sources */,
+				F8D09FBC1BFD48F200FB2433 /* GCD.swift in Sources */,
 				E5915B211BDABC4B005E5D63 /* NSURLRequest.swift in Sources */,
 				F80695131B962C5300C61B4A /* NetworkRequestPerformer.swift in Sources */,
 				F8D09FB91BFD360A00FB2433 /* NSError.swift in Sources */,


### PR DESCRIPTION
- Add internal helper for performing actions on the main thread. We aren't
  exporting this as part of the public API.
  - Don't use a closure when we can just pass a function.
