### PR TITLE
Add the ability to parse error objects

### DIFF
--- a/Source/Extensions/Result.swift
+++ b/Source/Extensions/Result.swift
@@ -2,12 +2,12 @@ import Argo
 import Result
 
 public extension Result {
-  static func fromDecoded<T>(decoded: Decoded<T>) -> Result<T, NSError> {
+  static func fromDecoded<T>(decoded: Decoded<T>) -> Result<T, SwishError> {
     switch decoded {
     case let .Success(obj):
       return .Success(obj)
-    case let .Failure(decodedError):
-      return .Failure(.error(decodedError.description))
+    case let .Failure(error):
+      return .Failure(.ArgoError(error))
     }
   }
 }

--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -11,9 +11,9 @@ public struct APIClient {
 }
 
 extension APIClient: Client {
-  public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, NSError> -> Void) -> NSURLSessionDataTask {
+  public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, T.ResponseError> -> Void) -> NSURLSessionDataTask {
     return requestPerformer.performRequest(request.build()) { result in
-      let object = result >>- deserialize >>- request.parse
+      let object = (result >>- deserialize >>- request.parse).mapError(request.transformError)
       onMain { completionHandler(object) }
     }
   }

--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -45,5 +45,5 @@ private func parseJSON(response: HTTPResponse) -> Result<AnyObject, SwishError> 
       .JSONObjectWithData(data, options: NSJSONReadingOptions(rawValue: 0))
   )
 
-  return result.mapError(SwishError.JSONSerializationError)
+  return result.mapError(SwishError.InvalidJSONResponse)
 }

--- a/Source/Models/NetworkRequestPerformer.swift
+++ b/Source/Models/NetworkRequestPerformer.swift
@@ -10,10 +10,10 @@ public struct NetworkRequestPerformer: RequestPerformer {
 }
 
 public extension NetworkRequestPerformer {
-  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) -> NSURLSessionDataTask {
+  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, SwishError> -> Void) -> NSURLSessionDataTask {
     let task = session.dataTaskWithRequest(request) { data, response, error in
       if let error = error {
-        completionHandler(.Failure(error))
+        completionHandler(.Failure(.SessionError(error)))
       } else {
         let response = HTTPResponse(data: data, response: response)
         completionHandler(.Success(response))

--- a/Source/Models/NetworkRequestPerformer.swift
+++ b/Source/Models/NetworkRequestPerformer.swift
@@ -13,7 +13,7 @@ public extension NetworkRequestPerformer {
   func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, SwishError> -> Void) -> NSURLSessionDataTask {
     let task = session.dataTaskWithRequest(request) { data, response, error in
       if let error = error {
-        completionHandler(.Failure(.SessionError(error)))
+        completionHandler(.Failure(.URLSessionError(error)))
       } else {
         let response = HTTPResponse(data: data, response: response)
         completionHandler(.Success(response))

--- a/Source/Models/SwishError.swift
+++ b/Source/Models/SwishError.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Argo
+
+public enum SwishError {
+  case SessionError(NSError)
+  case ServerError(code: Int, json: AnyObject)
+  case JSONSerializationError(NSError)
+  case ArgoError(DecodeError)
+}
+
+extension SwishError: ErrorType { }
+
+public extension SwishError {
+  var rawError: NSError {
+    switch self {
+    case let .SessionError(e):
+      return e
+    case let .JSONSerializationError(e):
+      return e
+    case let .ServerError(code, json):
+      return .error(code, json: json)
+    case let .ArgoError(e):
+      return .error(String(e))
+    }
+  }
+}

--- a/Source/Models/SwishError.swift
+++ b/Source/Models/SwishError.swift
@@ -2,10 +2,10 @@ import Foundation
 import Argo
 
 public enum SwishError {
-  case SessionError(NSError)
+  case ArgoError(Argo.DecodeError)
+  case InvalidJSONResponse(NSError)
   case ServerError(code: Int, json: AnyObject)
-  case JSONSerializationError(NSError)
-  case ArgoError(DecodeError)
+  case URLSessionError(NSError)
 }
 
 extension SwishError: ErrorType { }
@@ -13,9 +13,9 @@ extension SwishError: ErrorType { }
 public extension SwishError {
   var rawError: NSError {
     switch self {
-    case let .SessionError(e):
+    case let .URLSessionError(e):
       return e
-    case let .JSONSerializationError(e):
+    case let .InvalidJSONResponse(e):
       return e
     case let .ServerError(code, json):
       return .error(code, json: json)

--- a/Source/Protocols/Client.swift
+++ b/Source/Protocols/Client.swift
@@ -3,5 +3,5 @@ import Argo
 import Result
 
 public protocol Client {
-  func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, NSError> -> ()) -> NSURLSessionDataTask
+  func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, T.ResponseError> -> ()) -> NSURLSessionDataTask
 }

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -8,30 +8,30 @@ public protocol Request {
   typealias ResponseObject
   typealias ResponseError = NSError
   func build() -> NSURLRequest
-  func parse(j: JSON) -> Result<ResponseObject, NSError>
-  func transformError(error: NSError) -> ResponseError
+  func parse(j: JSON) -> Result<ResponseObject, SwishError>
+  func transformError(error: SwishError) -> ResponseError
 }
 
 public extension Request where ResponseObject: Decodable, ResponseObject.DecodedType == ResponseObject {
-  func parse(j: JSON) -> Result<ResponseObject, NSError> {
+  func parse(j: JSON) -> Result<ResponseObject, SwishError> {
     return .fromDecoded(ResponseObject.decode(j))
   }
 }
 
 public extension Request where ResponseObject: CollectionType, ResponseObject.Generator.Element: Decodable, ResponseObject.Generator.Element.DecodedType == ResponseObject.Generator.Element {
-  func parse(j: JSON) -> Result<[ResponseObject.Generator.Element], NSError> {
+  func parse(j: JSON) -> Result<[ResponseObject.Generator.Element], SwishError> {
     return .fromDecoded(ResponseObject.decode(j))
   }
 }
 
 public extension Request where ResponseObject == EmptyResponse {
-  func parse(j: JSON) -> Result<ResponseObject, NSError> {
+  func parse(j: JSON) -> Result<ResponseObject, SwishError> {
     return .Success()
   }
 }
 
 public extension Request where ResponseError == NSError {
-  func transformError(error: NSError) -> ResponseError {
-    return error
+  func transformError(error: SwishError) -> ResponseError {
+    return error.rawError
   }
 }

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -6,8 +6,10 @@ public typealias EmptyResponse = Void
 
 public protocol Request {
   typealias ResponseObject
+  typealias ResponseError = NSError
   func build() -> NSURLRequest
   func parse(j: JSON) -> Result<ResponseObject, NSError>
+  func transformError(error: NSError) -> ResponseError
 }
 
 public extension Request where ResponseObject: Decodable, ResponseObject.DecodedType == ResponseObject {
@@ -25,5 +27,11 @@ public extension Request where ResponseObject: CollectionType, ResponseObject.Ge
 public extension Request where ResponseObject == EmptyResponse {
   func parse(j: JSON) -> Result<ResponseObject, NSError> {
     return .Success()
+  }
+}
+
+public extension Request where ResponseError == NSError {
+  func transformError(error: NSError) -> ResponseError {
+    return error
   }
 }

--- a/Source/Protocols/RequestPerformer.swift
+++ b/Source/Protocols/RequestPerformer.swift
@@ -2,5 +2,5 @@ import Foundation
 import Result
 
 public protocol RequestPerformer {
-  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void)-> NSURLSessionDataTask
+  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, SwishError> -> Void)-> NSURLSessionDataTask
 }

--- a/Swish.xcodeproj/project.pbxproj
+++ b/Swish.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		F80695141B962C5300C61B4A /* RequestPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F806950F1B962C5300C61B4A /* RequestPerformer.swift */; };
 		F80695161B962C5300C61B4A /* Swish.h in Headers */ = {isa = PBXBuildFile; fileRef = F80695121B962C5300C61B4A /* Swish.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F80695181B9633C400C61B4A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F80695171B9633C400C61B4A /* Result.framework */; };
+		F84374CE1C4032020092E844 /* SwishError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F59BB51C2B34B60020B5BE /* SwishError.swift */; };
 		F867938C1BD29E37007D9E98 /* RequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = F867938B1BD29E37007D9E98 /* RequestMethod.swift */; };
 		F88ED0691B966E650069F56C /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88ED0681B966E650069F56C /* Request.swift */; };
 		F88ED06B1B966EC00069F56C /* Argo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88ED06A1B966EC00069F56C /* Argo.framework */; };
@@ -59,6 +60,7 @@
 		F8DF3B8B1B964B83003177CD /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DF3B891B964B83003177CD /* Nimble.framework */; };
 		F8DF3B8C1B964B83003177CD /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DF3B8A1B964B83003177CD /* Quick.framework */; };
 		F8DF3B8E1B964BED003177CD /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DF3B8D1B964BED003177CD /* HTTPResponse.swift */; };
+		F8F59BB61C2B34B60020B5BE /* SwishError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F59BB51C2B34B60020B5BE /* SwishError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -110,6 +112,7 @@
 		F8DF3B891B964B83003177CD /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8DF3B8A1B964B83003177CD /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8DF3B8D1B964BED003177CD /* HTTPResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
+		F8F59BB51C2B34B60020B5BE /* SwishError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwishError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -199,6 +202,7 @@
 		F806950C1B962C5300C61B4A /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				F8F59BB51C2B34B60020B5BE /* SwishError.swift */,
 				F867938B1BD29E37007D9E98 /* RequestMethod.swift */,
 				F806950D1B962C5300C61B4A /* NetworkRequestPerformer.swift */,
 				F8DF3B8D1B964BED003177CD /* HTTPResponse.swift */,
@@ -469,6 +473,7 @@
 				2C721E581BD5A7C500846414 /* HTTPResponse.swift in Sources */,
 				2C721E5C1BD5A7E800846414 /* NetworkRequestPerformer.swift in Sources */,
 				2C721E571BD5A7C500846414 /* Result.swift in Sources */,
+				F84374CE1C4032020092E844 /* SwishError.swift in Sources */,
 				F8D09FBD1BFD48F200FB2433 /* GCD.swift in Sources */,
 				2C721E5B1BD5A7D400846414 /* Request.swift in Sources */,
 				2C721E5A1BD5A7D400846414 /* RequestPerformer.swift in Sources */,
@@ -503,6 +508,7 @@
 				F88ED0691B966E650069F56C /* Request.swift in Sources */,
 				F80695141B962C5300C61B4A /* RequestPerformer.swift in Sources */,
 				F88ED06D1B96736B0069F56C /* APIClient.swift in Sources */,
+				F8F59BB61C2B34B60020B5BE /* SwishError.swift in Sources */,
 				F8D09FBC1BFD48F200FB2433 /* GCD.swift in Sources */,
 				E5915B211BDABC4B005E5D63 /* NSURLRequest.swift in Sources */,
 				F80695131B962C5300C61B4A /* NetworkRequestPerformer.swift in Sources */,

--- a/Tests/Fakes/FakeRequest.swift
+++ b/Tests/Fakes/FakeRequest.swift
@@ -10,7 +10,7 @@ struct FakeRequest: Request {
     return NSURLRequest(URL: NSURL(string: "http://example.com")!)
   }
 
-  func parse(j: JSON) -> Result<String, NSError> {
+  func parse(j: JSON) -> Result<String, SwishError> {
     return .fromDecoded(j <| "text")
   }
 }

--- a/Tests/Fakes/FakeRequestPerformer.swift
+++ b/Tests/Fakes/FakeRequestPerformer.swift
@@ -31,7 +31,7 @@ class FakeRequestPerformer: RequestPerformer {
     self.statusCode = statusCode
   }
 
-  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) -> NSURLSessionDataTask {
+  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, SwishError> -> Void) -> NSURLSessionDataTask {
     passedRequest = request
 
     let response = request.URL.flatMap {

--- a/Tests/Tests/APIClientSpec.swift
+++ b/Tests/Tests/APIClientSpec.swift
@@ -41,7 +41,7 @@ class APIClientSpec: QuickSpec {
               it("returns a failure state to the completion block") {
                 let request = FakeRequest()
                 let performer = FakeRequestPerformer(
-                  responseData: .JSON( ["foo": "bar"])
+                  responseData: .JSON(["foo": "bar"])
                 )
 
                 let client = APIClient(requestPerformer: performer)

--- a/Tests/Tests/NetworkRequestPerformerSpec.swift
+++ b/Tests/Tests/NetworkRequestPerformerSpec.swift
@@ -55,7 +55,7 @@ class RequestPerformerSpec: QuickSpec {
 
             let performer = NetworkRequestPerformer(session: fakeSession)
             performer.performRequest(exampleRequest()) { result in
-              returnedError = result.error!
+              returnedError = result.error?.rawError
             }
 
             expect(returnedError).to(equal(error))


### PR DESCRIPTION
This adds a `transformError` function to `Request`. This acts as a hook
to be able to change the error from the `NSError` used by the lower
level network clients and JSON parsing into a model more suitable for
your application.

By default, we are still going to return `NSError`s, but it's useful to
have a hook for being able to model the network error response if you
know what it looks like.

This maintains 100% backwards compatibility with the existing API.

Fixes #46
