### PR TITLE
Return data tasks when performing requests

### DIFF
--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -11,8 +11,8 @@ public struct APIClient {
 }
 
 extension APIClient: Client {
-  public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> Void) {
-    requestPerformer.performRequest(request.build()) { result in
+  public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> Void) -> NSURLSessionDataTask {
+    return requestPerformer.performRequest(request.build()) { result in
       let object = result >>- deserialize >>- request.parse
       onMain { completionHandler(object) }
     }

--- a/Source/Models/NetworkRequestPerformer.swift
+++ b/Source/Models/NetworkRequestPerformer.swift
@@ -10,14 +10,17 @@ public struct NetworkRequestPerformer: RequestPerformer {
 }
 
 public extension NetworkRequestPerformer {
-  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) {
-    session.dataTaskWithRequest(request) { data, response, error in
+  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) -> NSURLSessionDataTask {
+    let task = session.dataTaskWithRequest(request) { data, response, error in
       if let error = error {
         completionHandler(.Failure(error))
       } else {
         let response = HTTPResponse(data: data, response: response)
         completionHandler(.Success(response))
       }
-    }.resume()
+    }
+
+    task.resume()
+    return task
   }
 }

--- a/Source/Protocols/Client.swift
+++ b/Source/Protocols/Client.swift
@@ -3,5 +3,5 @@ import Argo
 import Result
 
 public protocol Client {
-  func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> ())
+  func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> ()) -> NSURLSessionDataTask
 }

--- a/Source/Protocols/RequestPerformer.swift
+++ b/Source/Protocols/RequestPerformer.swift
@@ -2,5 +2,5 @@ import Foundation
 import Result
 
 public protocol RequestPerformer {
-  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void)
+  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void)-> NSURLSessionDataTask
 }

--- a/Tests/Fakes/FakeRequestPerformer.swift
+++ b/Tests/Fakes/FakeRequestPerformer.swift
@@ -12,7 +12,7 @@ class FakeRequestPerformer: RequestPerformer {
     self.statusCode = statusCode
   }
 
-  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) {
+  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) -> NSURLSessionDataTask {
     passedRequest = request
     let data = returnedJSON.flatMap {
       try? NSJSONSerialization.dataWithJSONObject($0, options: NSJSONWritingOptions(rawValue: 0))
@@ -26,6 +26,8 @@ class FakeRequestPerformer: RequestPerformer {
     let result: Result<HTTPResponse, NSError> = .Success(HTTPResponse(data: data, response: response))
 
     completionHandler(result)
+
+    return NSURLSessionDataTask()
   }
 }
 
@@ -37,7 +39,7 @@ class FakeEmptyResponseRequestPerformer: RequestPerformer {
     self.statusCode = statusCode
   }
   
-  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) {
+  func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) -> NSURLSessionDataTask {
     passedRequest = request
     let data = NSData()
     
@@ -49,5 +51,7 @@ class FakeEmptyResponseRequestPerformer: RequestPerformer {
     let result: Result<HTTPResponse, NSError> = .Success(HTTPResponse(data: data, response: response))
     
     completionHandler(result)
+
+    return NSURLSessionDataTask()
   }
 }


### PR DESCRIPTION
Previously, we were throwing away the data tasks created by
NSURLSession. This made the API simpler, but the end result was that
there was no way to cancel a request once it started.

By returning the data task, we can now leave it up to the consumer on
how to handle canceling requests. If they want the old behavior, they
can simply continue to ignore the return result. But if they want, they
can now hold onto the task that is returned, and cancel it or do
whatever they need to do with it.
