### PR TITLE
Fix warning in `beVoid` matcher

### DIFF
--- a/Tests/Helpers/NimbleMatchers.swift
+++ b/Tests/Helpers/NimbleMatchers.swift
@@ -18,7 +18,7 @@ public func beVoid() -> MatcherFunc<Void> {
 public func beSuccessful<T, E>() -> NonNilMatcherFunc<Result<T, E>> {
   return NonNilMatcherFunc { actual, failure in
     let result = try actual.evaluate()
-    
+
     switch result {
     case .Success?: return true
     default: return false

--- a/Tests/Helpers/NimbleMatchers.swift
+++ b/Tests/Helpers/NimbleMatchers.swift
@@ -5,12 +5,10 @@ public func beVoid() -> MatcherFunc<Void> {
   return MatcherFunc { actualExpression, failureMessage in
     failureMessage.postfixMessage = "equal ()"
 
-    let actualValue = try actualExpression.evaluate()
+    let actualValue: Void? = try actualExpression.evaluate()
     switch actualValue {
-    case .Some(()):
-      return true
-    default:
-      return false
+    case ()?: return true
+    default: return false
     }
   }
 }

--- a/Tests/Tests/APIClientSpec.swift
+++ b/Tests/Tests/APIClientSpec.swift
@@ -66,17 +66,17 @@ class APIClientSpec: QuickSpec {
                 expect(result!.value!).toEventually(beVoid())
               }
             }
-            
+
             context("when the data is empty") {
               it("returns a null JSON object") {
                 let request = FakeEmptyDataRequest()
                 let performer = FakeEmptyResponseRequestPerformer()
-                
+
                 let client = APIClient(requestPerformer: performer)
                 var result: Result<EmptyResponse, NSError>?
-                
+
                 client.performRequest(request) { result = $0 }
-                
+
                 expect(result!.value!).toEventually(beVoid())
               }
             }


### PR DESCRIPTION
Previously we weren't being explicit about the fact that this expression
evaluation was expected to return `Void?`. Since this is a fairly unusual
return type, Xcode was throwing warnings about it, which dirtied the
project's build status and was generally noisy.

To fix this, we can be explicit about expecting `Void?`.

While I'm at it, I'll take the time to clean up the implementation a
little.
