### PR TITLE
Remove duplicate test

### DIFF
--- a/Tests/Fakes/FakeRequest.swift
+++ b/Tests/Fakes/FakeRequest.swift
@@ -15,34 +15,10 @@ struct FakeRequest: Request {
   }
 }
 
-struct FakeNullDataRequest: Request {
-  typealias ResponseObject = ()
-
-  func build() -> NSURLRequest {
-    return NSURLRequest(URL: NSURL(string: "http://example.com")!)
-  }
-
-  func parse(j: JSON) -> Result<(), NSError> {
-    switch j {
-    case JSON.Null: return Result.Success(())
-    default:
-      return Result.Failure(Result<(), NSError>.error())
-    }
-  }
-}
-
 struct FakeEmptyDataRequest: Request {
   typealias ResponseObject = EmptyResponse
 
   func build() -> NSURLRequest {
     return NSURLRequest(URL: NSURL(string: "http://example.com")!)
-  }
-
-  func parse(j: JSON) -> Result<EmptyResponse, NSError> {
-    switch j {
-    case JSON.Null: return Result.Success(())
-    default:
-      return Result.Failure(Result<EmptyResponse, NSError>.error())
-    }
   }
 }

--- a/Tests/Fakes/FakeRequestPerformer.swift
+++ b/Tests/Fakes/FakeRequestPerformer.swift
@@ -34,22 +34,22 @@ class FakeRequestPerformer: RequestPerformer {
 class FakeEmptyResponseRequestPerformer: RequestPerformer {
   let statusCode: Int
   var passedRequest: NSURLRequest?
-  
+
   init(statusCode: Int = 204) {
     self.statusCode = statusCode
   }
-  
+
   func performRequest(request: NSURLRequest, completionHandler: Result<HTTPResponse, NSError> -> Void) -> NSURLSessionDataTask {
     passedRequest = request
     let data = NSData()
-    
+
     var response: NSHTTPURLResponse? = .None
     if let url = request.URL {
       response = NSHTTPURLResponse(URL: url, statusCode: statusCode, HTTPVersion: .None, headerFields: .None)
     }
-    
+
     let result: Result<HTTPResponse, NSError> = .Success(HTTPResponse(data: data, response: response))
-    
+
     completionHandler(result)
 
     return NSURLSessionDataTask()

--- a/Tests/Tests/APIClientSpec.swift
+++ b/Tests/Tests/APIClientSpec.swift
@@ -53,20 +53,6 @@ class APIClientSpec: QuickSpec {
               }
             }
 
-            context("when the data is `nil`") {
-              it("returns a null JSON object") {
-                let request = FakeNullDataRequest()
-                let performer = FakeRequestPerformer()
-
-                let client = APIClient(requestPerformer: performer)
-                var result: Result<(), NSError>?
-
-                client.performRequest(request) { result = $0 }
-
-                expect(result!.value!).toEventually(beVoid())
-              }
-            }
-
             context("when the data is empty") {
               it("returns a null JSON object") {
                 let request = FakeEmptyDataRequest()

--- a/Tests/Tests/APIClientSpec.swift
+++ b/Tests/Tests/APIClientSpec.swift
@@ -10,7 +10,9 @@ class APIClientSpec: QuickSpec {
         describe("performRequest(completionHandler:") {
           it("passes the request's request object to the request performer") {
             let request = FakeRequest()
-            let performer = FakeRequestPerformer()
+            let performer = FakeRequestPerformer(
+              responseData: .JSON([:])
+            )
             let client = APIClient(requestPerformer: performer)
 
             client.performRequest(request) { _ in }
@@ -22,8 +24,8 @@ class APIClientSpec: QuickSpec {
             context("when the parsing operation is successful") {
               it("returns the parsed object to the completion block") {
                 let request = FakeRequest()
-                let performer = FakeRequestPerformer(returnedJSON:
-                  ["text": "hello world"]
+                let performer = FakeRequestPerformer(
+                  responseData: .JSON(["text": "hello world"])
                 )
 
                 let client = APIClient(requestPerformer: performer)
@@ -38,8 +40,8 @@ class APIClientSpec: QuickSpec {
             context("when the parsing operation fails") {
               it("returns a failure state to the completion block") {
                 let request = FakeRequest()
-                let performer = FakeRequestPerformer(returnedJSON:
-                  ["foo": "bar"]
+                let performer = FakeRequestPerformer(
+                  responseData: .JSON( ["foo": "bar"])
                 )
 
                 let client = APIClient(requestPerformer: performer)
@@ -56,14 +58,16 @@ class APIClientSpec: QuickSpec {
             context("when the data is empty") {
               it("returns a null JSON object") {
                 let request = FakeEmptyDataRequest()
-                let performer = FakeEmptyResponseRequestPerformer()
+                let performer = FakeRequestPerformer(
+                  responseData: .Data(NSData())
+                )
 
                 let client = APIClient(requestPerformer: performer)
                 var result: Result<EmptyResponse, NSError>?
 
                 client.performRequest(request) { result = $0 }
 
-                expect(result!.value!).toEventually(beVoid())
+                expect(result?.value).toEventually(beVoid())
               }
             }
           }
@@ -71,7 +75,9 @@ class APIClientSpec: QuickSpec {
           describe("completionHandler") {
             it("performs on the main thread") {
               let request = FakeRequest()
-              let performer = FakeRequestPerformer()
+              let performer = FakeRequestPerformer(
+                responseData: .JSON([:])
+              )
 
               let client = APIClient(requestPerformer: performer)
               var isMainThread = false
@@ -90,7 +96,7 @@ class APIClientSpec: QuickSpec {
         it("returns the appropriate error") {
           let request = FakeRequest()
           let performer = FakeRequestPerformer(
-            returnedJSON: ["foo": "bar"],
+            responseData: .JSON(["foo": "bar"]),
             statusCode: 301
           )
 
@@ -109,7 +115,7 @@ class APIClientSpec: QuickSpec {
         it("returns the appropriate error") {
           let request = FakeRequest()
           let performer = FakeRequestPerformer(
-            returnedJSON: ["foo": "bar"],
+            responseData: .JSON(["foo": "bar"]),
             statusCode: 401
           )
 
@@ -128,7 +134,7 @@ class APIClientSpec: QuickSpec {
         it("returns the appropriate error") {
           let request = FakeRequest()
           let performer = FakeRequestPerformer(
-            returnedJSON: ["foo": "bar"],
+            responseData: .JSON(["foo": "bar"]),
             statusCode: 500
           )
 
@@ -147,7 +153,7 @@ class APIClientSpec: QuickSpec {
         it("returns the appropriate error") {
           let request = FakeRequest()
           let performer = FakeRequestPerformer(
-            returnedJSON: ["foo": "bar"],
+            responseData: .JSON(["foo": "bar"]),
             statusCode: 600
           )
 
@@ -167,7 +173,7 @@ class APIClientSpec: QuickSpec {
           let expectedJSON = ["foo": "bar"]
           let request = FakeRequest()
           let performer = FakeRequestPerformer(
-            returnedJSON: expectedJSON,
+            responseData: .JSON(expectedJSON),
             statusCode: 600
           )
 

--- a/Tests/Tests/APIClientSpec.swift
+++ b/Tests/Tests/APIClientSpec.swift
@@ -70,6 +70,22 @@ class APIClientSpec: QuickSpec {
                 expect(result?.value).toEventually(beVoid())
               }
             }
+
+            context("when the data is .None") {
+              it("returns a null JSON object") {
+                let request = FakeEmptyDataRequest()
+                let performer = FakeRequestPerformer(
+                  responseData: .Data(.None)
+                )
+
+                let client = APIClient(requestPerformer: performer)
+                var result: Result<EmptyResponse, NSError>?
+
+                client.performRequest(request) { result = $0 }
+
+                expect(result?.value).toEventually(beVoid())
+              }
+            }
           }
 
           describe("completionHandler") {


### PR DESCRIPTION
The null data test and the empty data test were identical. In addition, the
custom `parse` function in our empty request was duplicated, since we're
providing it for free with an extension on `Request`.
