### PR TITLE
Rename ResponseType to ResponseObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func baseRequest(url url: String, method: RequestMethod) {
 }
 
 struct CommentRequest: Request {
-  typealias ResponseType = Comment
+  typealias ResponseObject = Comment
 
   let id: Int
 
@@ -69,13 +69,13 @@ APIClient().performRequest(request) { (response: Result<Comment, NSError>) in
 
 We declare a struct that conforms to the `Request` protocol, which forces us to:
 
-* Declare a `ResponseType` that should be `Decodable`, which allows Swish to use
+* Declare a `ResponseObject` that should be `Decodable`, which allows Swish to use
   Argo to decode the HTTP response into the appropriate model.
 * Declare a `build` function, which defines the request to perform.
   HTTP method to use.
 
 Then, we can use `APIClient#performRequest` to actually perform the request, and
-its callback will have an argument of type `Result<ResponseType, NSError>`.
+its callback will have an argument of type `Result<ResponseObject, NSError>`.
 
 ## Advanced Usage
 One can additionally override the default implementation of both
@@ -89,7 +89,7 @@ The default `APIClient#performRequest` does the following:
 * Pass this `JSON` to the `Request#parse` function.
 
 The default `Request#parse` just passes the `JSON` it is called with to the
-`ResponseType.decode` function.
+`ResponseObject.decode` function.
 
 As an example of a custom `parse` function, let's assume that in the example
 above, the API returns an array of objects, and we want to parse only the first
@@ -97,7 +97,7 @@ one into a `Comment`, or otherwise fail:
 
 ```swift
 struct CommentRequest: Request {
-  typealias ResponseType = Comment
+  typealias ResponseObject = Comment
 
   let id: Int
 

--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -11,7 +11,7 @@ public struct APIClient {
 }
 
 extension APIClient: Client {
-  public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> Void) -> NSURLSessionDataTask {
+  public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, NSError> -> Void) -> NSURLSessionDataTask {
     return requestPerformer.performRequest(request.build()) { result in
       let object = result >>- deserialize >>- request.parse
       onMain { completionHandler(object) }

--- a/Source/Protocols/Client.swift
+++ b/Source/Protocols/Client.swift
@@ -3,5 +3,5 @@ import Argo
 import Result
 
 public protocol Client {
-  func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseType, NSError> -> ()) -> NSURLSessionDataTask
+  func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, NSError> -> ()) -> NSURLSessionDataTask
 }

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -5,25 +5,25 @@ import Result
 public typealias EmptyResponse = Void
 
 public protocol Request {
-  typealias ResponseType
+  typealias ResponseObject
   func build() -> NSURLRequest
-  func parse(j: JSON) -> Result<ResponseType, NSError>
+  func parse(j: JSON) -> Result<ResponseObject, NSError>
 }
 
-public extension Request where ResponseType: Decodable, ResponseType.DecodedType == ResponseType {
-  func parse(j: JSON) -> Result<ResponseType, NSError> {
-    return .fromDecoded(ResponseType.decode(j))
+public extension Request where ResponseObject: Decodable, ResponseObject.DecodedType == ResponseObject {
+  func parse(j: JSON) -> Result<ResponseObject, NSError> {
+    return .fromDecoded(ResponseObject.decode(j))
   }
 }
 
-public extension Request where ResponseType: CollectionType, ResponseType.Generator.Element: Decodable, ResponseType.Generator.Element.DecodedType == ResponseType.Generator.Element {
-  func parse(j: JSON) -> Result<[ResponseType.Generator.Element], NSError> {
-    return .fromDecoded(ResponseType.decode(j))
+public extension Request where ResponseObject: CollectionType, ResponseObject.Generator.Element: Decodable, ResponseObject.Generator.Element.DecodedType == ResponseObject.Generator.Element {
+  func parse(j: JSON) -> Result<[ResponseObject.Generator.Element], NSError> {
+    return .fromDecoded(ResponseObject.decode(j))
   }
 }
 
-public extension Request where ResponseType == EmptyResponse {
-  func parse(j: JSON) -> Result<ResponseType, NSError> {
+public extension Request where ResponseObject == EmptyResponse {
+  func parse(j: JSON) -> Result<ResponseObject, NSError> {
     return .Success()
   }
 }

--- a/Tests/Fakes/FakeRequest.swift
+++ b/Tests/Fakes/FakeRequest.swift
@@ -33,11 +33,11 @@ struct FakeNullDataRequest: Request {
 
 struct FakeEmptyDataRequest: Request {
   typealias ResponseObject = EmptyResponse
-  
+
   func build() -> NSURLRequest {
     return NSURLRequest(URL: NSURL(string: "http://example.com")!)
   }
-  
+
   func parse(j: JSON) -> Result<EmptyResponse, NSError> {
     switch j {
     case JSON.Null: return Result.Success(())

--- a/Tests/Fakes/FakeRequest.swift
+++ b/Tests/Fakes/FakeRequest.swift
@@ -4,7 +4,7 @@ import Argo
 import Result
 
 struct FakeRequest: Request {
-  typealias ResponseType = String
+  typealias ResponseObject = String
 
   func build() -> NSURLRequest {
     return NSURLRequest(URL: NSURL(string: "http://example.com")!)
@@ -16,7 +16,7 @@ struct FakeRequest: Request {
 }
 
 struct FakeNullDataRequest: Request {
-  typealias ResponseType = ()
+  typealias ResponseObject = ()
 
   func build() -> NSURLRequest {
     return NSURLRequest(URL: NSURL(string: "http://example.com")!)
@@ -32,7 +32,7 @@ struct FakeNullDataRequest: Request {
 }
 
 struct FakeEmptyDataRequest: Request {
-  typealias ResponseType = EmptyResponse
+  typealias ResponseObject = EmptyResponse
   
   func build() -> NSURLRequest {
     return NSURLRequest(URL: NSURL(string: "http://example.com")!)

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -6,31 +6,31 @@ import Result
 
 struct User: Decodable {
   let name: String
-  
+
   static func decode(json: JSON) -> Decoded<User> {
     return User.init <^> json <| "name"
   }
 }
 
 struct DecodableRequest: Request {
-  typealias ResponseType = User
-  
+  typealias ResponseObject = User
+
   func build() -> NSURLRequest {
     return NSURLRequest()
   }
 }
 
 struct DecodableCollectionRequest: Request {
-  typealias ResponseType = [User]
-  
+  typealias ResponseObject = [User]
+
   func build() -> NSURLRequest {
     return NSURLRequest()
   }
 }
 
 struct EmptyResponseRequest: Request {
-  typealias ResponseType = EmptyResponse
-  
+  typealias ResponseObject = EmptyResponse
+
   func build() -> NSURLRequest {
     return NSURLRequest()
   }
@@ -40,15 +40,15 @@ class RequestSpec: QuickSpec {
   override func spec() {
     describe("Request") {
       describe("default parse implementation") {
-        context("when the ResponseType is decodable") {
+        context("when the ResponseObject is decodable") {
           let request = DecodableRequest()
           let json = JSON.parse(["name": "gvg"])
           let result = request.parse(json)
           
           expect(result.value?.name).to(equal("gvg"))
         }
-        
-        context("when the ResponseType is a collection type of decodable objects") {
+
+        context("when the ResponseObject is a collection type of decodable objects") {
           let request = DecodableCollectionRequest()
           let json = JSON.parse([
             ["name": "giles"],
@@ -59,8 +59,8 @@ class RequestSpec: QuickSpec {
           expect(result.value?.count).to(equal(2))
           expect(result.value?.first?.name).to(equal("giles"))
         }
-        
-        context("when the ResponseType is an EmptyResponse") {
+
+        context("when the ResponseObject is an EmptyResponse") {
           it("should result in Success") {
             let request = EmptyResponseRequest()
             let result = request.parse(.Null)

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -44,7 +44,7 @@ class RequestSpec: QuickSpec {
           let request = DecodableRequest()
           let json = JSON.parse(["name": "gvg"])
           let result = request.parse(json)
-          
+
           expect(result.value?.name).to(equal("gvg"))
         }
 
@@ -55,7 +55,7 @@ class RequestSpec: QuickSpec {
             ["name": "gordon"]
           ])
           let result = request.parse(json)
-          
+
           expect(result.value?.count).to(equal(2))
           expect(result.value?.first?.name).to(equal("giles"))
         }
@@ -64,7 +64,7 @@ class RequestSpec: QuickSpec {
           it("should result in Success") {
             let request = EmptyResponseRequest()
             let result = request.parse(.Null)
-            
+
             expect(result).to(beSuccessful())
           }
         }


### PR DESCRIPTION
`ResponseType` made sense to me when I initially wrote this, but as time
went on it made less and less sense. With #47, I think it stops making
sense entirely. This renames `ResponseType` to `ResponseObject` in order to
hopefully clarify the intent a bit more.
