### PR TITLE
Allow top level arrays in jsonPayload

### DIFF
--- a/Source/Extensions/NSURLRequest.swift
+++ b/Source/Extensions/NSURLRequest.swift
@@ -1,14 +1,19 @@
 import Foundation
 
 public extension NSURLRequest {
-  var jsonPayload: NSDictionary {
+  var jsonPayload: AnyObject {
     let json = HTTPBody.flatMap { try? NSJSONSerialization.JSONObjectWithData($0, options: NSJSONReadingOptions(rawValue: 0)) }
-    return (json as? [String: AnyObject]) ?? [:]
+    if let jsonDict = json as? [String: AnyObject] {
+      return jsonDict
+    }
+
+    let jsonArray = json as? [AnyObject]
+    return jsonArray ?? [:]
   }
 }
 
 public extension NSMutableURLRequest {
-  override var jsonPayload: NSDictionary {
+  override var jsonPayload: AnyObject {
     get {
       return super.jsonPayload
     }

--- a/Tests/Tests/NSURLRequestSpec.swift
+++ b/Tests/Tests/NSURLRequestSpec.swift
@@ -10,10 +10,22 @@ class NSURLRequestSpec: QuickSpec {
           let urlRequest = NSMutableURLRequest(URL: NSURL(string: "http://www.example.com")!)
           urlRequest.jsonPayload = ["ids": [0, 1, 2]]
 
-          let payloadFromRequest = urlRequest.jsonPayload
-          let ids: [Int]? = payloadFromRequest["ids"] as? [Int]
+          let payloadFromRequest = urlRequest.jsonPayload as? [String: AnyObject]
+          let ids = payloadFromRequest?["ids"] as? [Int]
 
           expect(ids).to(equal([0, 1, 2]))
+        }
+      }
+
+      context("when given an encodable array") {
+        it("serializes and deserializes correctly") {
+          let urlRequest = NSMutableURLRequest(URL: NSURL(string: "http://www.example.com")!)
+          urlRequest.jsonPayload = [["id": 1]]
+
+          let payloadFromRequest = urlRequest.jsonPayload as? [[String: AnyObject]]
+          let item = payloadFromRequest?[0]["id"] as? Int
+
+          expect(item).to(equal(1))
         }
       }
 
@@ -22,9 +34,9 @@ class NSURLRequestSpec: QuickSpec {
           let urlRequest = NSMutableURLRequest(URL: NSURL(string: "http://www.example.com")!)
           urlRequest.HTTPBody = NSData()
 
-          let payloadFromRequest = urlRequest.jsonPayload
+          let payloadFromRequest = urlRequest.jsonPayload as? [String: AnyObject]
 
-          expect(payloadFromRequest.count).to(equal(0))
+          expect(payloadFromRequest?.count).to(equal(0))
         }
       }
     }


### PR DESCRIPTION
- `jsonPayload` now returns type `AnyObject?`, expecting the user to
  type cast appropriately

Damian and I were working on this, and came up this.

While `AnyObject?` isn't ideal, our thoughts are that once the end user sets `.jsonPayload = ...`, they probably won't have a reason to fetch/manipulate it afterward.

Another solution we considered was a SwishRequest, that contained both the `NSMutableURLRequest` and a `JSONPayload` enum that had cases for arrays and dictionaries. This added a lot of overhead in code in exchange for no gain, as far as we could tell.
