### PR TITLE
Remove hard dependence on JSON

### DIFF
--- a/Source/Extensions/NSError.swift
+++ b/Source/Extensions/NSError.swift
@@ -2,7 +2,7 @@ import Foundation
 
 private let swishDomain = "com.thoughtbot.swish"
 
-public let NetworkErrorJSONKey = swishDomain + ".errorJSON"
+public let NetworkErrorDataKey = swishDomain + ".errorData"
 
 extension NSError {
   static func error(message: String, function: String = #function, file: String = #file, line: Int = #line) -> NSError {
@@ -13,11 +13,11 @@ extension NSError {
     return NSError(domain: swishDomain, code: 0, userInfo: info)
   }
 
-  static func error(statusCode: Int, json: AnyObject, function: String = #function, file: String = #file, line: Int = #line) -> NSError {
+  static func error(statusCode: Int, data: AnyObject?, function: String = #function, file: String = #file, line: Int = #line) -> NSError {
     var info = userInfoFor(function, file, line)
 
     info[NSLocalizedDescriptionKey] = messageForStatusCode(statusCode)
-    info[NetworkErrorJSONKey] = json
+    info[NetworkErrorDataKey] = data
 
     return NSError(domain: swishDomain, code: statusCode, userInfo: info)
   }

--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -4,46 +4,35 @@ import Result
 
 public struct APIClient {
   private let requestPerformer: RequestPerformer
+  private let deserializer: Deserializer
 
-  public init(requestPerformer: RequestPerformer = NetworkRequestPerformer()) {
+  public init(requestPerformer: RequestPerformer = NetworkRequestPerformer(), deserializer: Deserializer = JSONDeserializer()) {
     self.requestPerformer = requestPerformer
+    self.deserializer = deserializer
   }
 }
 
 extension APIClient: Client {
   public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, SwishError> -> Void) -> NSURLSessionDataTask {
     return requestPerformer.performRequest(request.build()) { result in
-      let object = result >>- deserialize >>- request.parse
+      let object = result
+        >>- self.validateResponse
+        >>- self.deserializer.deserialize
+        >>- T.ResponseParser.parse
+        >>- request.parse
+
       onMain { completionHandler(object) }
     }
   }
 }
 
-private func deserialize(response: HTTPResponse) -> Result<JSON, SwishError> {
-  let json = parseJSON(response)
-
-  switch (response.code, json) {
-
-  case let (_, .Failure(e)):
-    return .Failure(e)
-
-  case let (200...299, .Success(j)):
-    return .Success(JSON(j))
-
-  case let (code, .Success(j)):
-    return .Failure(.ServerError(code: code, json: j))
+private extension APIClient {
+  func validateResponse(httpResponse: HTTPResponse) -> Result<NSData?, SwishError> {
+    switch httpResponse.code {
+    case (200...299):
+      return .Success(httpResponse.data)
+    default:
+      return .Failure(.ServerError(code: httpResponse.code, data: httpResponse.data))
+    }
   }
-}
-
-private func parseJSON(response: HTTPResponse) -> Result<AnyObject, SwishError> {
-  guard let data = response.data where data.length > 0 else {
-    return .Success(NSNull())
-  }
-
-  let result = materialize(
-    try NSJSONSerialization
-      .JSONObjectWithData(data, options: NSJSONReadingOptions(rawValue: 0))
-  )
-
-  return result.mapError(SwishError.InvalidJSONResponse)
 }

--- a/Source/Models/JSONDeserializer.swift
+++ b/Source/Models/JSONDeserializer.swift
@@ -1,0 +1,34 @@
+import Argo
+import Result
+
+struct JSONDeserializer: Deserializer {
+  func deserialize(data: NSData?) -> Result<AnyObject, SwishError> {
+    let json = self.parseJSON(data)
+
+    return json.analysis(
+      ifSuccess: Result<AnyObject, SwishError>.init,
+      ifFailure: { .Failure(.InvalidJSONResponse($0)) }
+    )
+  }
+}
+
+extension JSON: Parser {
+  public typealias Representation = JSON
+
+  public static func parse(j: AnyObject) -> Result<JSON, SwishError> {
+    return Result(JSON.init(j))
+  }
+}
+
+private extension JSONDeserializer {
+  private func parseJSON(data: NSData?) -> Result<AnyObject, NSError> {
+    guard let d = data where d.length > 0 else {
+      return .Success(NSNull())
+    }
+
+    return Result(
+      try NSJSONSerialization
+        .JSONObjectWithData(d, options: NSJSONReadingOptions(rawValue: 0))
+    )
+  }
+}

--- a/Source/Models/SwishError.swift
+++ b/Source/Models/SwishError.swift
@@ -4,7 +4,7 @@ import Argo
 public enum SwishError {
   case ArgoError(Argo.DecodeError)
   case InvalidJSONResponse(NSError)
-  case ServerError(code: Int, json: AnyObject)
+  case ServerError(code: Int, data: NSData?)
   case URLSessionError(NSError)
 }
 
@@ -18,7 +18,7 @@ public extension SwishError {
     case let .InvalidJSONResponse(e):
       return e
     case let .ServerError(code, json):
-      return .error(code, json: json)
+      return .error(code, data: json)
     case let .ArgoError(e):
       return .error(String(e))
     }
@@ -33,8 +33,8 @@ public func == (lhs: SwishError, rhs: SwishError) -> Bool {
     return l == r
   case let (.InvalidJSONResponse(l), .InvalidJSONResponse(r)):
     return l == r
-  case let (.ServerError(lCode, lJSON), .ServerError(rCode, rJSON)):
-    return lCode == rCode && JSON(lJSON) == JSON(rJSON)
+  case let (.ServerError(lCode, lData), .ServerError(rCode, rData)):
+    return lCode == rCode && lData == rData
   case let (.URLSessionError(l), .URLSessionError(r)):
     return l == r
   default:

--- a/Source/Protocols/Deserializer.swift
+++ b/Source/Protocols/Deserializer.swift
@@ -1,0 +1,5 @@
+import Result
+
+public protocol Deserializer {
+  func deserialize(data: NSData?) -> Result<AnyObject, SwishError>
+}

--- a/Source/Protocols/Parser.swift
+++ b/Source/Protocols/Parser.swift
@@ -1,0 +1,7 @@
+import Result
+
+public protocol Parser {
+  associatedtype Representation
+
+  static func parse(j: AnyObject) -> Result<Representation, SwishError>
+}

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -6,8 +6,10 @@ public typealias EmptyResponse = Void
 
 public protocol Request {
   associatedtype ResponseObject
+  associatedtype ResponseParser: Parser = JSON
+
   func build() -> NSURLRequest
-  func parse(j: JSON) -> Result<ResponseObject, SwishError>
+  func parse(j: ResponseParser.Representation) -> Result<ResponseObject, SwishError>
 }
 
 public extension Request where ResponseObject: Decodable, ResponseObject.DecodedType == ResponseObject {

--- a/Swish.xcodeproj/project.pbxproj
+++ b/Swish.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		2C721E5D1BD5A7E800846414 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88ED06C1B96736B0069F56C /* APIClient.swift */; };
 		2C721E5E1BD5A83B00846414 /* Swish.h in Headers */ = {isa = PBXBuildFile; fileRef = F80695121B962C5300C61B4A /* Swish.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E506EC7E1BB5BE380032E941 /* NimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E506EC7D1BB5BE380032E941 /* NimbleMatchers.swift */; };
+		E58AD6331C91049300AD2CDE /* Deserializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58AD6321C91049300AD2CDE /* Deserializer.swift */; };
+		E58AD6351C91053000AD2CDE /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58AD6341C91053000AD2CDE /* Parser.swift */; };
+		E58AD6371C91055200AD2CDE /* JSONDeserializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58AD6361C91055200AD2CDE /* JSONDeserializer.swift */; };
 		E5915B211BDABC4B005E5D63 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5915B201BDABC4B005E5D63 /* NSURLRequest.swift */; };
 		E5915B221BDABC4B005E5D63 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5915B201BDABC4B005E5D63 /* NSURLRequest.swift */; };
 		E5915B241BDAD1A3005E5D63 /* NSURLRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5915B231BDAD1A3005E5D63 /* NSURLRequestSpec.swift */; };
@@ -84,6 +87,9 @@
 		2C721E401BD5A77700846414 /* Swish.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swish.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C721E491BD5A77700846414 /* Swish-MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Swish-MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E506EC7D1BB5BE380032E941 /* NimbleMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleMatchers.swift; sourceTree = "<group>"; };
+		E58AD6321C91049300AD2CDE /* Deserializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Deserializer.swift; sourceTree = "<group>"; };
+		E58AD6341C91053000AD2CDE /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		E58AD6361C91055200AD2CDE /* JSONDeserializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDeserializer.swift; sourceTree = "<group>"; };
 		E5915B201BDABC4B005E5D63 /* NSURLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLRequest.swift; sourceTree = "<group>"; };
 		E5915B231BDAD1A3005E5D63 /* NSURLRequestSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLRequestSpec.swift; sourceTree = "<group>"; };
 		E5D7E0A01BBF2021002A3738 /* Client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
@@ -207,6 +213,7 @@
 				F806950D1B962C5300C61B4A /* NetworkRequestPerformer.swift */,
 				F8DF3B8D1B964BED003177CD /* HTTPResponse.swift */,
 				F88ED06C1B96736B0069F56C /* APIClient.swift */,
+				E58AD6361C91055200AD2CDE /* JSONDeserializer.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -217,6 +224,8 @@
 				F806950F1B962C5300C61B4A /* RequestPerformer.swift */,
 				F88ED0681B966E650069F56C /* Request.swift */,
 				E5D7E0A01BBF2021002A3738 /* Client.swift */,
+				E58AD6321C91049300AD2CDE /* Deserializer.swift */,
+				E58AD6341C91053000AD2CDE /* Parser.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -505,6 +514,9 @@
 				F88EE3141B976747001EEB44 /* Result.swift in Sources */,
 				E5D7E0A11BBF2021002A3738 /* Client.swift in Sources */,
 				F8DF3B8E1B964BED003177CD /* HTTPResponse.swift in Sources */,
+				E58AD6371C91055200AD2CDE /* JSONDeserializer.swift in Sources */,
+				E58AD6351C91053000AD2CDE /* Parser.swift in Sources */,
+				E58AD6331C91049300AD2CDE /* Deserializer.swift in Sources */,
 				F88ED0691B966E650069F56C /* Request.swift in Sources */,
 				F80695141B962C5300C61B4A /* RequestPerformer.swift in Sources */,
 				F88ED06D1B96736B0069F56C /* APIClient.swift in Sources */,

--- a/Tests/Tests/APIClientSpec.swift
+++ b/Tests/Tests/APIClientSpec.swift
@@ -125,7 +125,7 @@ class APIClientSpec: QuickSpec {
             error = $0.error
           }
 
-          expect(error).toEventually(equal(SwishError.ServerError(code: expectedCode, json: expectedJSON)))
+          expect(error).toEventually(equal(SwishError.ServerError(code: expectedCode, data: performer.data)))
         }
       }
 
@@ -146,7 +146,7 @@ class APIClientSpec: QuickSpec {
             error = $0.error
           }
 
-          expect(error).toEventually(equal(SwishError.ServerError(code: expectedCode, json: expectedJSON)))
+          expect(error).toEventually(equal(SwishError.ServerError(code: expectedCode, data: performer.data)))
         }
       }
 
@@ -167,7 +167,7 @@ class APIClientSpec: QuickSpec {
             error = $0.error
           }
 
-          expect(error).toEventually(equal(SwishError.ServerError(code: expectedCode, json: expectedJSON)))
+          expect(error).toEventually(equal(SwishError.ServerError(code: expectedCode, data: performer.data)))
         }
       }
 
@@ -188,7 +188,7 @@ class APIClientSpec: QuickSpec {
             error = $0.error
           }
 
-          expect(error).toEventually(equal(SwishError.ServerError(code: expectedCode, json: expectedJSON)))
+          expect(error).toEventually(equal(SwishError.ServerError(code: expectedCode, data: performer.data)))
         }
       }
     }


### PR DESCRIPTION
- Adds a `var deserializer: Deserializer` to the `Client` protocol.
  
  Default implementation provided by `JSONDeserializer`.
- Adds a `typealias Decoder: Parser` to the `Request` protocol.
  
  Default implementation provided by `Argo.JSON`
