### PR TITLE
Use SwishError as our final error type

### DIFF
--- a/Source/Models/APIClient.swift
+++ b/Source/Models/APIClient.swift
@@ -11,9 +11,9 @@ public struct APIClient {
 }
 
 extension APIClient: Client {
-  public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, T.ResponseError> -> Void) -> NSURLSessionDataTask {
+  public func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, SwishError> -> Void) -> NSURLSessionDataTask {
     return requestPerformer.performRequest(request.build()) { result in
-      let object = (result >>- deserialize >>- request.parse).mapError(request.transformError)
+      let object = result >>- deserialize >>- request.parse
       onMain { completionHandler(object) }
     }
   }

--- a/Source/Models/SwishError.swift
+++ b/Source/Models/SwishError.swift
@@ -24,3 +24,20 @@ public extension SwishError {
     }
   }
 }
+
+extension SwishError: Equatable { }
+
+public func == (lhs: SwishError, rhs: SwishError) -> Bool {
+  switch (lhs, rhs) {
+  case let (.ArgoError(l), .ArgoError(r)):
+    return l == r
+  case let (.InvalidJSONResponse(l), .InvalidJSONResponse(r)):
+    return l == r
+  case let (.ServerError(lCode, lJSON), .ServerError(rCode, rJSON)):
+    return lCode == rCode && JSON(lJSON) == JSON(rJSON)
+  case let (.URLSessionError(l), .URLSessionError(r)):
+    return l == r
+  default:
+    return false
+  }
+}

--- a/Source/Protocols/Client.swift
+++ b/Source/Protocols/Client.swift
@@ -3,5 +3,5 @@ import Argo
 import Result
 
 public protocol Client {
-  func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, T.ResponseError> -> ()) -> NSURLSessionDataTask
+  func performRequest<T: Request>(request: T, completionHandler: Result<T.ResponseObject, SwishError> -> ()) -> NSURLSessionDataTask
 }

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -6,10 +6,8 @@ public typealias EmptyResponse = Void
 
 public protocol Request {
   associatedtype ResponseObject
-  associatedtype ResponseError = NSError
   func build() -> NSURLRequest
   func parse(j: JSON) -> Result<ResponseObject, SwishError>
-  func transformError(error: SwishError) -> ResponseError
 }
 
 public extension Request where ResponseObject: Decodable, ResponseObject.DecodedType == ResponseObject {
@@ -27,11 +25,5 @@ public extension Request where ResponseObject: CollectionType, ResponseObject.Ge
 public extension Request where ResponseObject == EmptyResponse {
   func parse(j: JSON) -> Result<ResponseObject, SwishError> {
     return .Success()
-  }
-}
-
-public extension Request where ResponseError == NSError {
-  func transformError(error: SwishError) -> ResponseError {
-    return error.rawError
   }
 }


### PR DESCRIPTION
Originally, we were trying to let users model their error types by
implementing a `transformError` function on their `Request` objects that
knew how to go from the generic error encountered by Swish to a more
explicit error type controlled by the client application.

Unfortunately, this was a fairly naive approach that ended up causing
more trouble than it was worth.
- Given that there were so many different places for the request to
  encounter an error, it wasn't nearly as simple to model the errors as
  it was the success cases. This means that the original intent of the
  API was lost from the start.
- It became confusing to know when you should use `SwishError` and when
  you should use `NSError`. The boundary was fairly blurry and users
  encountered both regularly.
- Being completely generic about the error type at the `Client` level
  made it extremely difficult to wrap. We had been using this in client
  applications for things like global error messaging, where we'd wrap
  the `Client` and then post a notification if we encountered an error
  at any time in the request process. This became basically impossible
  once we needed to refer to a generic type like `T.ResponseError`,
  because we had absolutely no clues as to what that object was. Given
  the rest of the issues listed above, this seemed like needlessly
  complicated API with no real concrete benefit.

That being said, having `SwishError` around as an error type _is_ a
better solution than `NSError` in the long run. This error type gives
the end user _much_ more context about exactly what went wrong, and that
will give them the ability to do something better with it. Therefore, I
think it makes sense to move to an all-`SwishError` interface, rather
than reverting to `NSError`.
