### PR TITLE
Add documentation around basic usage, public protocols

### DIFF
--- a/Documentation/Advanced.md
+++ b/Documentation/Advanced.md
@@ -1,0 +1,88 @@
+# Advanced Usage #
+
+What if the endpoints you need to query don't return JSON? Perhaps you have an
+endpoint, `GET https://www.example.com/isAuthorized` that returns a `200 OK`
+with `"yes"` or `"no"` as a response body. We'll have to do a few things:
+
+- Define a custom `ResponseParser` to provide to our `Request` object, because
+the default one parses `JSON`.
+- Define a custom `Deserializer` to provide to our `APIClient`, because the 
+default one uses `NSJSONSerialization`.
+
+We'll start with the custom `Deserializer`. It will simply pass along the 
+`NSData` if it exists:
+
+```swift
+struct StringDeserializer: Deserializer {
+  func deserialize(data: NSData?) -> Result<AnyObject, SwishError> {
+    guard let data = data where data.length > 0 else {
+      return .Success(NSNull())
+    }
+
+    return .Success(data)
+  }
+}
+```
+
+Then, our custom `ResponseParser` will use `String(data:encoding:)` to
+transform the incoming `NSData` to a `String` representation:
+
+```swift
+struct StringParser: Parser {
+  typealias Representation = String
+
+  static func parse(j: AnyObject) -> Result<String, SwishError> {
+    guard let data = j as? NSData else {
+      let error = NSError.error("Bad data!")
+
+      return .Failure(.InvalidJSONResponse(error))
+    }
+
+    let error = NSError.error("Couldn't convert to string!")
+    let string = String(data: data, encoding: NSUTF8StringEncoding)
+
+    return Result(string, failWith: .InvalidJSONResponse(error))
+  }
+}
+```
+
+Finally, our `Request` will convert the `String` into a `Bool`:
+
+```swift
+struct AuthorizedRequest: Request {
+  typealias ResponseObject = Bool
+  typealias ResponseParser = StringParser
+
+  func build() -> NSURLRequest {
+    let endpoint = NSURL(string: "https://www.example.com/isAuthorized")!
+
+    return NSURLRequest(URL: endpoint)
+  }
+
+  func parse(j: String) -> Result<Bool, SwishError> {
+    switch j {
+      case "yes":
+        return Result(true)
+      case "no":
+        return Result(false)
+      default:
+        let error = NSError.error("Unexpected response body!")
+        return Result(error: .InvalidJSONResponse(error))
+    }
+  }
+}
+```
+
+Now, we're ready to make our request:
+
+```swift
+let client = APIClient(
+  requestPerformer: NetworkRequestPerformer(),
+  deserializer: StringDeserializer()
+)
+let request = AuthorizedRequest()
+
+let dataTask = client.performRequest(request) { (result: Result<Bool, SwishError>) in
+  // whatever you need to do
+}
+```

--- a/Documentation/Basics.md
+++ b/Documentation/Basics.md
@@ -1,0 +1,61 @@
+# Basic Usage #
+
+Let's say you have an endpoint, `GET https://www.example.com/comments/1`, that returns the following JSON:
+
+```json
+{
+  "id": 1,
+  "commentText": "Pretty good. Pret-ty pre-ty pre-ty good.",
+  "username": "LarryDavid"
+}
+```
+
+We'll model this with the following struct, and implement Argo's `Decodable` protocol to tell it how to deal with JSON:
+
+```swift
+import Argo
+import Curry
+
+struct Comment: Decodable {
+  let id: Int
+  let text: String
+  let username: String
+
+  static func decode(json: JSON) -> Decoded<Comment> {
+    return curry(Comment.init)
+      <^> j <| "id"
+      <*> j <| "commentText"
+      <*> j <| "username"
+  }
+}
+```
+
+We can model the request by defining a struct that implement's Swish's `Request` protocol:
+
+```swift
+struct CommentRequest: Request {
+  typealias ResponseObject = Comment
+  let id: Int
+
+  func build() -> NSURLRequest {
+    let url = NSURL(string: "https://www.example.com/comments/\(id)")!
+    return NSURLRequest(URL: url)
+  }
+}
+```
+
+We can then use the Swish's default `APIClient` to make the request:
+
+```swift
+let request = CommentRequest(id: 1)
+
+let dataTask = APIClient().performRequest(request) { (response: Result<Comment, SwishError>) in
+  if let value = response.value {
+    print("Here's the comment: \(value)")
+  } else if let error = response.error {
+    print("Oh no, an error: \(error)")
+  }
+}
+```
+
+And that's it!

--- a/Documentation/Protocols.md
+++ b/Documentation/Protocols.md
@@ -1,0 +1,54 @@
+# Protocols #
+
+This documents each public protocol's intended use and the defaults for each that come built in to Swish.
+
+At a  high level, here's what goes on:
+
+* A `Client` is told to perform a `Request`, which is done via the `RequestPerformer`.
+* The `RequestPerformer` will ensure it has a valid HTTP response code, and if so, hand the `NSData` from the `HTTPResponse` to the `Deserializer`.
+* The `Deserializer` will convert this `NSData` into a `Representation`, which is specified by the `Request`'s `ResponseParser`. The idea here is that the `Deserializer` can convert `NSData` into an intermediary form that can then be parsed into the `ResponseObject`.
+
+In diagram form:
+
+```swift
+Request —— RequestPerformer.performRequest ——> NSData
+        —— Deserializer.deserialize —————————> AnyObject
+        —— Parser.parse —————————————————————> Parser.Representation
+        —— Request.parse ————————————————————> Request.ResponseObject
+```
+
+When translated into the concrete types given by the Swish defaults:
+
+```swift
+Request —— NetworkRequestPerformer.performRequest ——> NSData
+        —— JSONDeserializer.deserialize ————————————> AnyObject
+        —— JSON.parse ——————————————————————————————> JSON
+        —— Request.parse ———————————————————————————> Request.ResponseObject
+```
+
+### Request ###
+
+The `Request` protocol models a requestable object (for example, a JSON endpoint). In addition, it defines two associated types:
+
+- A `ResponseObject` that defines what type of object to expect back from the request.
+- A `ResponseParser` that conforms to the `Parser` protocol, which provides a way to go from `AnyObject` into the `Parser.Representation`.
+
+It is the job of a `Request` to convert from the `Parser.Representation` into the `ResponseObject`. It does the via the `parse` function.
+
+### Parser ###
+The `Parser` protocol defines a way to convert `AnyObject` into a `Representation`. This `Representation` is then fed into the `Request.parse` function to produce a `ResponseObject`.
+
+### Deserializer ###
+The `Deserializer` protocol defines a way to convert `NSData?` into `AnyObject`. The `AnyObject` can then be fed into `Request.ResponseParser.parse`.
+
+### Client ###
+
+The `Client` protocol defines the core `performRequest` method that handles tying the other protocols together. It requires an object of type `Deserializer` that is responsible for dealing with the response's `NSData`.
+
+The provided `Client` in Swish is `APIClient`. `APIClient` is instantiated (by default) with a `NetworkRequestPerformer` and a `JSONDeserializer`.
+
+### RequestPerformer ###
+
+The `RequestPerformer` protocol defines the layer that actually performs the raw networking.
+
+The default `RequestPerformer` is `NetworkRequestPerformer` that makes network requests via `NSURLSession`.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,11 @@
+# Documentation #
+
+Swish is a protocol oriented networking library. It aims to be flexible, non-invasive, and easy to test.
+
+## Basic Usage ##
+- [Working with JSON Responses](Basics.md)
+
+## Advanced Usage ##
+- [Customizing Swish by implementing protocols](Protocols.md)
+- [An example for using Swish with non-JSON responses](Advanced.md)
+

--- a/README.md
+++ b/README.md
@@ -27,111 +27,17 @@ for up to date installation instructions.
 
 [carthage-installation]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application
 
-## Basic Usage
-```swift
-import Swish
+## Usage
 
-func baseRequest(url url: String, method: RequestMethod) -> NSURLRequest {
-  let url = NSURL(string: url)!
-  let request = NSMutableURLRequest(URL: url)
+- tl;dr: [Basic Usage][basics]
+- Otherwise, see the [Documentation][docs]
 
-  request.HTTPMethod = method.rawValue
-  return request
-}
-
-struct CommentRequest: Request {
-  typealias ResponseObject = Comment
-
-  let id: Int
-
-  func build() -> NSURLRequest {
-    let endpoint = "http://example.com/api/comment/\(id)"
-
-    return baseRequest(endpoint: endpoint, method: .GET)
-  }
-}
-
-struct Comment: Decodable {
-  let id: Int
-  let text: String
-  let username: String
-
-  static func decode(j: JSON) -> Decoded<Comment> {
-    return curry(Comment.init)
-      <^> j <| "id"
-      <*> j <| "commentText"
-      <*> j <| "username"
-  }
-}
-
-let request = CommentRequest(id: 1)
-APIClient().performRequest(request) { (response: Result<Comment, NSError>) in
-  // ...
-}
-```
-
-We declare a struct that conforms to the `Request` protocol, which forces us to:
-
-* Declare a `ResponseObject` that should be `Decodable`, which allows Swish to use
-  Argo to decode the HTTP response into the appropriate model.
-* Declare a `build` function, which defines the request to perform.
-  HTTP method to use.
-
-Then, we can use `APIClient#performRequest` to actually perform the request, and
-its callback will have an argument of type `Result<ResponseObject, NSError>`.
-
-## Advanced Usage
-One can additionally override the default implementation of both
-`APIClient#performRequest` and `Request#parse` to provide more custom behavior.
-
-The default `APIClient#performRequest` does the following:
-
-* Check that the HTTP Status Code is between `200...299`, else return an
-  `NSError`.
-* Parse the response's data into `Argo.JSON`
-* Pass this `JSON` to the `Request#parse` function.
-
-The default `Request#parse` just passes the `JSON` it is called with to the
-`ResponseObject.decode` function.
-
-As an example of a custom `parse` function, let's assume that in the example
-above, the API returns an array of objects, and we want to parse only the first
-one into a `Comment`, or otherwise fail:
-
-```swift
-struct CommentRequest: Request {
-  typealias ResponseObject = Comment
-
-  let id: Int
-
-  func build() -> NSURLRequest {
-    let endpoint = "http://example.com/api/comment/\(id)"
-
-    return baseRequest(endpoint: endpoint, method: .GET)
-  }
-
-  func parse(j: JSON) -> Result<Comment, NSError> {
-    let comments = [Comment].decode(j)
-    let comment = comments.flatmap { comments -> Decoded<Comment> in
-      guard let comment = comments.first else {
-        return .Failure(.Custom("No comments returned!"))
-      }
-
-      return .Success(comment)
-    }
-
-    return .fromDecoded(comment)
-  }
-}
-```
-
-Here, our parse function will first decode into an array of `Comment` objects,
-and then return the first if found, otherwise an error. The `fromDecoded`
-function converts from Argo's `Decoded<T>` type to `Result<T, NSError>`.
+[docs]: [/Documentation]
+[basics]: [/Documentation/Basics.md]
 
 ## License
 
-Swish is Copyright (c) 2015 thoughtbot, inc. It is free software, and may be
+Swish is Copyright (c) 2016 thoughtbot, inc. It is free software, and may be
 redistributed under the terms specified in the [LICENSE] file.
 
 [LICENSE]: /LICENSE

--- a/Source/Models/JSONDeserializer.swift
+++ b/Source/Models/JSONDeserializer.swift
@@ -7,7 +7,7 @@ struct JSONDeserializer: Deserializer {
 
     return json.analysis(
       ifSuccess: Result<AnyObject, SwishError>.init,
-      ifFailure: { .Failure(.InvalidJSONResponse($0)) }
+      ifFailure: { .Failure(.InvalidDeserializeError($0)) }
     )
   }
 }

--- a/Source/Models/SwishError.swift
+++ b/Source/Models/SwishError.swift
@@ -3,7 +3,8 @@ import Argo
 
 public enum SwishError {
   case ArgoError(Argo.DecodeError)
-  case InvalidJSONResponse(NSError)
+  case DeserializationError(NSError)
+  case ParseError(NSError)
   case ServerError(code: Int, data: NSData?)
   case URLSessionError(NSError)
 }
@@ -15,7 +16,9 @@ public extension SwishError {
     switch self {
     case let .URLSessionError(e):
       return e
-    case let .InvalidJSONResponse(e):
+    case let .ParseError(e):
+      return e
+    case let .DeserializationError(e):
       return e
     case let .ServerError(code, json):
       return .error(code, data: json)
@@ -31,7 +34,9 @@ public func == (lhs: SwishError, rhs: SwishError) -> Bool {
   switch (lhs, rhs) {
   case let (.ArgoError(l), .ArgoError(r)):
     return l == r
-  case let (.InvalidJSONResponse(l), .InvalidJSONResponse(r)):
+  case let (.ParseError(l), .ParseError(r)):
+    return l == r
+  case let (.DeserializationError(l), .DeserializationError(r)):
     return l == r
   case let (.ServerError(lCode, lData), .ServerError(rCode, rData)):
     return lCode == rCode && lData == rData


### PR DESCRIPTION
(I've put `sr-remove-json-dependence` as the base branch just to give a reasonable diff)

`Documentation/Basics.md` has basic Swish usage
`Documentation/Protocols.md` has a heuristic explanation of the protocols, as well as a short discussion on the intention of each

cc @thoughtbot/ios @thoughtbot/copy-editing 
