### PR TITLE
[Refactor] Update RequestMethod naming convention to Swift 3

### DIFF
--- a/Source/Models/RequestMethod.swift
+++ b/Source/Models/RequestMethod.swift
@@ -1,11 +1,11 @@
 public enum RequestMethod: String {
-  case GET
-  case POST
-  case DELETE
-  case PUT
-  case PATCH
-  case HEAD
-  case OPTIONS
-  case TRACE
-  case CONNECT
+  case get     = "GET"
+  case post    = "POST"
+  case delete  = "DELETE"
+  case put     = "PUT"
+  case patch   = "PATCH"
+  case head    = "HEAD"
+  case options = "OPTIONS"
+  case trace   = "TRACE"
+  case connect = "CONNECT"
 }


### PR DESCRIPTION
The enumeration object according to Swift 3 is a lower case naming convention.