### PR TITLE
Remove @testable from tests

### DIFF
--- a/Tests/Fakes/FakeRequestPerformer.swift
+++ b/Tests/Fakes/FakeRequestPerformer.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import Swish
+import Swish
 import Result
 
 enum ResponseData {

--- a/Tests/Tests/NetworkRequestPerformerSpec.swift
+++ b/Tests/Tests/NetworkRequestPerformerSpec.swift
@@ -1,4 +1,4 @@
-@testable import Swish
+import Swish
 import Quick
 import Nimble
 import Result

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -1,4 +1,4 @@
-@testable import Swish
+import Swish
 import Argo
 import Quick
 import Nimble


### PR DESCRIPTION
We aren't accessing any internal properties or methods, so we don't actually
need to use @testable here.