### PR TITLE
Fix building Swish 2.0 for Xcode 9.3

### DIFF
--- a/Source/Models/JSONDeserializer.swift
+++ b/Source/Models/JSONDeserializer.swift
@@ -1,8 +1,8 @@
 import Argo
 import Result
 
-struct JSONDeserializer: Deserializer {
-  func deserialize(_ data: Data?) -> Result<Any, SwishError> {
+public struct JSONDeserializer: Deserializer {
+  public func deserialize(_ data: Data?) -> Result<Any, SwishError> {
     let json = parseJSON(data)
 
     return json.analysis(
@@ -10,6 +10,8 @@ struct JSONDeserializer: Deserializer {
       ifFailure: { .failure(.deserializationError($0.error)) }
     )
   }
+
+  public init() {}
 }
 
 extension JSON: Parser {

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -26,6 +26,10 @@ public extension Request where ResponseObject: Collection, ResponseObject.Iterat
 
 public extension Request where ResponseObject == EmptyResponse {
   func parse(_ j: JSON) -> Result<ResponseObject, SwishError> {
-    return .success()
+    #if swift(>=3.3)
+      return .success(())
+    #else
+      return .success()
+    #endif
   }
 }


### PR DESCRIPTION
Xcode 9.3 brings along Swift 3.3, which has a couple _slightly_ different
behaviors that need to be special cased. Our current release (3.0+) of Swish
handles these changes already, but some users are unable to upgrade right now,
and we shouldn't make their lives more difficult.

This adds the fixes for Swift 3.3 without breaking compatibility for Swift 3.2
users.

I'm opening this PR for visibility but I'm going to delete the 2.0.3 branch as soon as I have a 2.0.3 release tagged.

Fixes #118 