### PR TITLE
Fix a bug where optional ResponseObject types produced an error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: "10.1.0"
+      xcode: "10.2.1"
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -10,7 +10,7 @@ public protocol Request {
 }
 
 public extension Request where ResponseObject: Decodable {
-  func parse<Wrapped>(_ data: Data) throws -> ResponseObject where ResponseObject == Optional<Wrapped> {
+  func parse<Wrapped>(_ data: Data) -> ResponseObject where ResponseObject == Optional<Wrapped> {
     return try? JSONDecoder().decode(ResponseObject.self, from: data)
   }
 

--- a/Source/Protocols/Request.swift
+++ b/Source/Protocols/Request.swift
@@ -10,7 +10,11 @@ public protocol Request {
 }
 
 public extension Request where ResponseObject: Decodable {
-  func parse(_ data: Data) throws -> ResponseObject {
+  func parse<Wrapped>(_ data: Data) throws -> ResponseObject where ResponseObject == Optional<Wrapped> {
+    return try? JSONDecoder().decode(ResponseObject.self, from: data)
+  }
+
+  func parse<Wrapped>(_ data: Data) throws -> ResponseObject where ResponseObject == Wrapped {
     return try JSONDecoder().decode(ResponseObject.self, from: data)
   }
 }

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -86,7 +86,7 @@ class RequestSpec: QuickSpec {
         context("when the ResponseObject is an optional type") {
           it("should result in Success") {
             let request = OptionalResponseRequest()
-            expect { try request.parse(Data()) }.toNot(throwError())
+            expect { request.parse(Data()) }.to(beNil())
           }
         }
       }

--- a/Tests/Tests/RequestSpec.swift
+++ b/Tests/Tests/RequestSpec.swift
@@ -30,6 +30,14 @@ struct EmptyResponseRequest: Request {
   }
 }
 
+struct OptionalResponseRequest: Request {
+  typealias ResponseObject = User?
+
+  func build() -> URLRequest {
+    return URLRequest(url: URL(string: "https://example.com")!)
+  }
+}
+
 func json(_ string: String) -> Data {
   return string.data(using: .utf8)!
 }
@@ -71,6 +79,13 @@ class RequestSpec: QuickSpec {
         context("when the ResponseObject is an EmptyResponse") {
           it("should result in Success") {
             let request = EmptyResponseRequest()
+            expect { try request.parse(Data()) }.toNot(throwError())
+          }
+        }
+
+        context("when the ResponseObject is an optional type") {
+          it("should result in Success") {
+            let request = OptionalResponseRequest()
             expect { try request.parse(Data()) }.toNot(throwError())
           }
         }


### PR DESCRIPTION
https://github.com/thoughtbot/Swish/issues/125

When a `Request`'s `ResponseObject` was declared to be `Optional<T>`
where `T: Decodable`, Swish would erroneously produce a, `DecodingError`
if the HTTP response had empty body data.

This commit specializes the default `parse` implementation into two variants:

- One for when `typealias ResponseObject = T?`
- One for when `typealias ResponseObject = T`