### PR TITLE
Adjust Podspec for 4.0.0

### DIFF
--- a/Swish.podspec
+++ b/Swish.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Swish'
-  spec.version = '3.0.0'
+  spec.version = '4.0.0'
   spec.summary = 'Nothing but net(working)'
   spec.homepage = 'https://github.com/thoughtbot/Swish'
   spec.license = { :type => 'MIT', :file => 'LICENSE' }

--- a/Swish.podspec
+++ b/Swish.podspec
@@ -13,8 +13,6 @@ Pod::Spec.new do |spec|
   spec.source = { :git => 'https://github.com/thoughtbot/Swish.git', :tag => "v#{spec.version}" }
   spec.source_files = 'Source/**/*.{h,swift}'
 
-  spec.dependency 'Result', '~> 4.0'
-
   spec.requires_arc = true
 
   spec.ios.deployment_target = '8.0'


### PR DESCRIPTION
It seems that the Podspec was not updated for 4.0.0 which caught me by surprised as I was trying to update my dependencies.

Since 4.0.0 uses the Swift standard library `Result` the dependency was dropped from the Cartfile but not the Podspec.